### PR TITLE
A temp. fix to get node compiling on OS X under pkgsrc-wic.

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -17,6 +17,11 @@ HAS_CONFIGURE=	yes
 USE_TOOLS+=	pkg-config
 USE_TOOLS+=	gmake
 USE_LANGUAGES=	c c++
+USE_LIBTOOL=    yes
+
+.if ${OPSYS} == "Darwin"
+PKG_LIBTOOL=    /usr/bin/libtool
+.endif
 
 .include "../../mk/bsd.prefs.mk"
 .include "options.mk"

--- a/node/options.mk
+++ b/node/options.mk
@@ -2,7 +2,7 @@
 
 PKG_OPTIONS_VAR=	PKG_OPTIONS.node
 PKG_SUPPORTED_OPTIONS=	openssl dtrace
-PKG_SUGGESTED_OPTIONS=	openssl
+PKG_SUGGESTED_OPTIONS=
 
 .if ${OPSYS} == "SunOS" && exists(/usr/sbin/dtrace)
 PKG_SUGGESTED_OPTIONS+=	dtrace
@@ -17,9 +17,13 @@ CONFIGURE_ARGS+=	--without-dtrace
 .endif
 
 .if !empty(PKG_OPTIONS:Mopenssl)
-.include "../../security/openssl/buildlink3.mk"
-.else
-CONFIGURE_ARGS+=	--without-openssl
+# As node already includes openssl, should we use the included one (static) or
+# security/openssl one as a dynamic lib
+BUILDLINK_API_DEPENDS.openssl+= openssl>=0.9.8
+CONFIGURE_ARGS+=  --shared-openssl
+CONFIGURE_ARGS+=  --shared-openssl-includes=${BUILDLINK_PREFIX.openssl:Q}/include
+CONFIGURE_ARGS+=  --shared-openssl-libpath=${BUILDLINK_PREFIX.openssl:Q}/lib
+. include "../../security/openssl/buildlink3.mk"
 .endif
 
 .if empty(PKG_OPTIONS:Msnapshot)


### PR DESCRIPTION
Gyp does not know about the differences in libtool, so use the one it
expects (/usr/bin/libtool) if OS is Darwin.

OpenSSL is included in node as a static library.

If using node-modules that require OpenSSL (node-guardtime), then
node must be compiled with a shared openssl.  If the option 'openssl'
is specified, we will build node against a shared openssl and depending on
PREFER_PKGSRC, this will either be security/openssl or system openssl.
