### PR TITLE
collectd5: update to 5.4, fix build on SmartOS, enable some more plugins

### DIFF
--- a/collectd5/Makefile
+++ b/collectd5/Makefile
@@ -1,8 +1,8 @@
 # $NetBSD$
 #
 
-DISTNAME=	collectd-5.0.1
-MASTER_SITES=	http://collectd.org/files/
+DISTNAME=       collectd-5.4.0
+MASTER_SITES=   http://collectd.org/files/
 CATEGORIES=     net
 
 MAINTAINER=	msporleder@gmail.com
@@ -10,32 +10,54 @@ HOMEPAGE=	http://collectd.org/
 COMMENT=	Statistics collection daemon - base
 LICENSE=	gnu-gpl-v2
 
-GNU_CONFIGURE=		yes
-USE_LIBTOOL=		yes
-USE_TOOLS+=		pkg-config
-USE_LANGUAGES=		c c++
+GNU_CONFIGURE=       yes
+USE_LIBTOOL=         yes
+USE_TOOLS+=          pkg-config autoconf
+USE_LANGUAGES=       c c++
+
+CONFIGURE_ARGS+=     --sysconfdir=${PKG_SYSCONFDIR}
+
+EGDIR=               ${PREFIX}/share/examples/${PKGBASE}
+CONF_FILES+=         ${EGDIR}/collectd.conf ${PKG_SYSCONFDIR}/collectd.conf
+INSTALL_MAKE_FLAGS+= sysconfdir=${EGDIR}
 
 CONFIGURE_ARGS+=	--with-included-ltdl
 CONFIGURE_ARGS+=	--disable-all-plugins
+CONFIGURE_ARGS+=	--enable-apache
+CONFIGURE_ARGS+=	--enable-cpu
 CONFIGURE_ARGS+=	--enable-csv
-CONFIGURE_ARGS+=	--enable-exec
-CONFIGURE_ARGS+=	--enable-logfile
-CONFIGURE_ARGS+=	--enable-filecount
+CONFIGURE_ARGS+=	--enable-curl_json
 CONFIGURE_ARGS+=	--enable-df
-CONFIGURE_ARGS+=	--enable-tail
-CONFIGURE_ARGS+=	--enable-table
-CONFIGURE_ARGS+=	--enable-syslog
-CONFIGURE_ARGS+=	--enable-unixsock
+CONFIGURE_ARGS+=	--enable-disk
+CONFIGURE_ARGS+=	--enable-exec
+CONFIGURE_ARGS+=	--enable-filecount
+CONFIGURE_ARGS+=	--enable-load
+CONFIGURE_ARGS+=	--enable-logfile
 CONFIGURE_ARGS+=	--enable-memcached
+CONFIGURE_ARGS+=	--enable-memory
+CONFIGURE_ARGS+=	--enable-mysql
 CONFIGURE_ARGS+=	--enable-network
-CONFIGURE_ARGS+=	--enable-olsrd
+CONFIGURE_ARGS+=	--enable-nginx
 CONFIGURE_ARGS+=	--enable-ntpd
+CONFIGURE_ARGS+=	--enable-olsrd
+CONFIGURE_ARGS+=	--enable-openvpn
 CONFIGURE_ARGS+=	--enable-powerdns
+CONFIGURE_ARGS+=	--enable-syslog
+CONFIGURE_ARGS+=	--enable-table
+CONFIGURE_ARGS+=	--enable-tail
+CONFIGURE_ARGS+=	--enable-unixsock
 CONFIGURE_ARGS+=	--enable-uptime
+CONFIGURE_ARGS+=	--enable-write_graphite
+CONFIGURE_ARGS+=	--enable-zfs_arc
 CONFIGURE_ARGS+=	--with-perl-bindings=no
 CONFIGURE_ARGS+=	--with-libperl=no
 
 PKGCONFIG_OVERRIDE+=	src/libcollectdclient/libcollectdclient.pc.in
+
+pre-configure:
+	cd ${WRKSRC} && autoconf
+
+AUTOMAKE_OVERRIDE=NO
 
 .include "../../devel/libltdl/convenience.mk"
 .include "../../mk/bsd.prefs.mk"

--- a/collectd5/PLIST
+++ b/collectd5/PLIST
@@ -1,27 +1,41 @@
 @comment $NetBSD$
 bin/collectd-nagios
+bin/collectd-tg
 bin/collectdctl
-etc/collectd.conf
 include/collectd/client.h
 include/collectd/lcc_features.h
+include/collectd/network.h
+include/collectd/network_buffer.h
+lib/collectd/apache.la
+lib/collectd/cpu.la
 lib/collectd/csv.la
+lib/collectd/curl_json.la
 lib/collectd/df.la
+lib/collectd/disk.la
 lib/collectd/exec.la
 lib/collectd/filecount.la
+lib/collectd/load.la
 lib/collectd/logfile.la
 lib/collectd/memcached.la
+lib/collectd/memory.la
+lib/collectd/mysql.la
 lib/collectd/network.la
+lib/collectd/nginx.la
 lib/collectd/ntpd.la
 lib/collectd/olsrd.la
+lib/collectd/openvpn.la
 lib/collectd/powerdns.la
 lib/collectd/syslog.la
 lib/collectd/table.la
 lib/collectd/tail.la
 lib/collectd/unixsock.la
 lib/collectd/uptime.la
+lib/collectd/write_graphite.la
+lib/collectd/zfs_arc.la
 lib/libcollectdclient.la
 lib/pkgconfig/libcollectdclient.pc
 man/man1/collectd-nagios.1
+man/man1/collectd-tg.1
 man/man1/collectd.1
 man/man1/collectdctl.1
 man/man1/collectdmon.1
@@ -39,6 +53,7 @@ sbin/collectd
 sbin/collectdmon
 share/collectd/postgresql_default.conf
 share/collectd/types.db
+share/examples/collectd/collectd.conf
 @pkgdir var/run
 @pkgdir var/log
 @pkgdir var/lib/collectd

--- a/collectd5/distinfo
+++ b/collectd5/distinfo
@@ -1,5 +1,6 @@
 $NetBSD$
 
-SHA1 (collectd-5.0.1.tar.gz) = ec1bf97d21a27d9b53b20f7dc4fb61441b4e42e0
-RMD160 (collectd-5.0.1.tar.gz) = b24c1e1399042517f98b6ef9725095c8bfdec462
-Size (collectd-5.0.1.tar.gz) = 1680960 bytes
+SHA1 (collectd-5.4.0.tar.gz) = a90fe6cc53b76b7bdd56dc57950d90787cb9c96e
+RMD160 (collectd-5.4.0.tar.gz) = be426e95b872fcf76fdaa01d330dfdd313cab470
+Size (collectd-5.4.0.tar.gz) = 1893721 bytes
+SHA1 (patch-configure.in) = 9f27c3716500b96563e64bae6837fa35e57842fd

--- a/collectd5/files/smf/manifest.xml
+++ b/collectd5/files/smf/manifest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type='manifest' name='collectd'>
+  <service name='@SMF_PREFI@/@SMF_NAME@' type='service' version='1'>
+    <create_default_instance enabled='false' />
+    <single_instance />
+    <dependency name='network' grouping='require_all' restart_on='none' type='service'>
+      <service_fmri value='svc:/milestone/network:default' />
+    </dependency>
+    <dependency name='filesystem-local' grouping='require_all' restart_on='none' type='service'>
+      <service_fmri value='svc:/system/filesystem/local:default' />
+    </dependency>
+    <exec_method type='method' name='start' exec='@PREFIX@/sbin/collectd' timeout_seconds='60'>
+      <method_context>
+        <method_credential user='root' group='root' />
+      </method_context>
+    </exec_method>
+    <exec_method type='method' name='stop' exec=':kill' timeout_seconds='60'>
+      <method_context>
+        <method_credential user='root' group='root' />
+      </method_context>
+    </exec_method>
+    <property_group name='startd' type='framework'>
+      <propval name="duration" type="astring" value="contract" />
+      <!-- sub-process core dumps shouldn't restart session -->
+      <propval name='ignore_error' type='astring' value='core,signal' />
+    </property_group>
+    <stability value='Evolving' />
+  </service>
+</service_bundle>

--- a/collectd5/patches/patch-configure.in
+++ b/collectd5/patches/patch-configure.in
@@ -1,0 +1,48 @@
+$NetBSD$
+
+fix detection of htonll
+--- configure.in.orig	2013-10-18 16:39:21.767316085 +0000
++++ configure.in
+@@ -1,5 +1,7 @@
+ dnl Process this file with autoconf to produce a configure script.
++AC_PREREQ([2.60])
+ AC_INIT(collectd, [m4_esyscmd(./version-gen.sh)])
++AC_USE_SYSTEM_EXTENSIONS
+ AC_CONFIG_SRCDIR(src/collectd.c)
+ AC_CONFIG_HEADERS(src/config.h)
+ AC_CONFIG_AUX_DIR([libltdl/config])
+@@ -1206,10 +1208,9 @@ if test "x$have_getmntent" = "xgen"; the
+ fi
+ 
+ # Check for htonll
+-AC_MSG_CHECKING([if have htonll defined])
+-
+-    have_htonll="no"
+-    AC_LINK_IFELSE([AC_LANG_PROGRAM(
++AC_CACHE_CHECK([if have htonll defined],
++                  [c_cv_have_htonll],
++                  AC_LINK_IFELSE([AC_LANG_PROGRAM(
+ [[[
+ #include <sys/types.h>
+ #include <netinet/in.h>
+@@ -1221,12 +1222,14 @@ AC_MSG_CHECKING([if have htonll defined]
+           return htonll(0);
+ ]]]
+     )],
+-    [
+-      have_htonll="yes"
+-      AC_DEFINE(HAVE_HTONLL, 1, [Define if the function htonll exists.])
+-    ])
+- 
+-AC_MSG_RESULT([$have_htonll])
++    [c_cv_have_htonll="yes"],
++    [c_cv_have_htonll="no"]
++       )
++)
++if test "x$c_cv_have_htonll" = "xyes"
++then
++    AC_DEFINE(HAVE_HTONLL, 1, [Define if the function htonll exists.])
++fi
+ 
+ # Check for structures
+ AC_CHECK_MEMBERS([struct if_data.ifi_ibytes, struct if_data.ifi_opackets, struct if_data.ifi_ierrors],


### PR DESCRIPTION
- updated collectd5 to 5.4.0
- configure detection of htonll was broken and needed a patch
- i enabled some more plugins (e.g. graphite support)
- i also copied over the smf file from the collectd 4 package, but i am not sure if i need to do something else to enable it
