### PR TITLE
Kirussel/libarchive

### DIFF
--- a/libarchive/Makefile
+++ b/libarchive/Makefile
@@ -12,6 +12,7 @@ LICENSE=	2-clause-bsd
 CONFLICTS+=	bsdtar-[0-9]*
 CONFLICTS+=	libarchive<=3.1.2
 
+TEST_TARGET=	check
 GNU_CONFIGURE=	yes
 USE_CMAKE=	yes
 USE_LIBTOOL=	yes

--- a/libarchive/Makefile
+++ b/libarchive/Makefile
@@ -12,7 +12,7 @@ LICENSE=	2-clause-bsd
 CONFLICTS+=	bsdtar-[0-9]*
 CONFLICTS+=	libarchive<=3.1.2
 
-TEST_TARGET=	check
+TEST_TARGET=	test
 GNU_CONFIGURE=	yes
 USE_CMAKE=	yes
 USE_LIBTOOL=	yes


### PR DESCRIPTION
I am adding test execution hooks to the libarchive Makefile to help reduce future libarchive regressions.

I noticed that libarchive-2.8.4nb4 does not work with iso files anymore.  To reproduce this issue, you can run the libarchive tests:
```
$ cd /usr/pkgsrc/archivers/libarchive
$ bmake TEST_TARGET=check test
[...]
47: test_read_format_iso_gz                           FAIL
```

I noticed that libarchive-3.1.2 appears to work with iso files. To verify, you can run the libarchive tests:
```
$ cd /usr/pkgsrc/wip/libarchive
$ bmake TEST_TARGET=test test
[...]
100% tests passed, 0 tests failed out of 404
```

This effects OS X Yosemite users because the default bsdtar appears to have the same iso regression.  So, I would like to use pkgsrc to get the latest working libarchive.

```
$ /usr/bin/bsdtar --version
bsdtar 2.8.3 - libarchive 2.8.3
```